### PR TITLE
Pin numpy less than 2.0

### DIFF
--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -12,7 +12,7 @@ about:
   For GPU support, install cudatoolkit 11.3.1 and cudnn 8.2.1 which are available as conda packages on the default channel.'
 
 build:
-  number: 0
+  number: 1
 
 source:
   path: ../
@@ -24,7 +24,7 @@ requirements:
 
   host:
     - python>=3.10.0,<3.11.0
-    - numpy
+    - numpy<2.0
     - h5py
     - protobuf
     - certifi
@@ -36,7 +36,7 @@ requirements:
 
   run:
     - python>=3.10.0,<3.11.0
-    - numpy
+    - numpy<2.0
     - h5py
     - protobuf
     - certifi

--- a/.github/workflows/build_tensorflow.yml
+++ b/.github/workflows/build_tensorflow.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - liezl/pin-numpy-less-than-2.0
 
     paths:
       - ".github/workflows/build_tensorflow.yml"


### PR DESCRIPTION
In the main SLEAP repo, we recently re-ran a [CI test](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433) on GA (without any changes to the source code) and were experiencing errors when importing `tensorflow`:

```bash
2024-10-02 16:45:05.510427: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/runner/miniconda3/envs/sleap_ci/lib:
2024-10-02 16:45:05.510483: I tensorflow/stream_executor/cuda/cudart_stub.cc:2[9](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433#step:6:10)] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
ImportError while loading conftest '/home/runner/work/sleap/sleap/tests/conftest.py'.
tests/conftest.py:9: in <module>
    from tests.fixtures.skeletons import *
tests/fixtures/skeletons.py:3: in <module>
    from sleap.skeleton import Skeleton
sleap/__init__.py:14: in <module>
    import sleap.nn
sleap/nn/__init__.py:1: in <module>
    import sleap.nn.architectures
sleap/nn/architectures/__init__.py:1: in <module>
    from sleap.nn.architectures import leap
sleap/nn/architectures/leap.py:[10](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433#step:6:11): in <module>
    from sleap.nn.architectures import encoder_decoder
sleap/nn/architectures/encoder_decoder.py:29: in <module>
    import tensorflow as tf
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/__init__.py:37: in <module>
    from tensorflow.python.tools import module_util as _module_util
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/python/__init__.py:37: in <module>
    from tensorflow.python.eager import context
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/python/eager/context.py:29: in <module>
    from tensorflow.core.framework import function_pb2
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/core/framework/function_pb2.py:[16](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433#step:6:17): in <module>
    from tensorflow.core.framework import attr_value_pb2 as tensorflow_dot_core_dot_framework_dot_attr__value__pb2
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/core/framework/attr_value_pb2.py:16: in <module>
    from tensorflow.core.framework import tensor_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__pb2
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/core/framework/tensor_pb2.py:16: in <module>
    from tensorflow.core.framework import resource_handle_pb2 as tensorflow_dot_core_dot_framework_dot_resource__handle__pb2
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/core/framework/resource_handle_pb2.py:16: in <module>
    from tensorflow.core.framework import tensor_shape_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__shape__pb2
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/tensorflow/core/framework/tensor_shape_pb2.py:36: in <module>
    _descriptor.FieldDescriptor(
../../../miniconda3/envs/sleap_ci/lib/python3.10/site-packages/google/protobuf/descriptor.py:621: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.[19](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433#step:6:20).0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.[20](https://github.com/talmolab/sleap/actions/runs/11147955727/job/30983484433#step:6:21).x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

This PR aims to fix those errors by adding additional constraints to the `tensorflow` package.